### PR TITLE
Some tests and changes in some protocols

### DIFF
--- a/bioinformatics/protocols/protocol_dali.py
+++ b/bioinformatics/protocols/protocol_dali.py
@@ -26,9 +26,12 @@
 import os
 import sys
 
+from bioinformatics.objects import SetOfDatabaseID, DatabaseID
+import pyworkflow.object as pwobj
 from pwem.protocols import EMProtocol
 from pwem.convert.atom_struct import AtomicStructHandler
 from pyworkflow.protocol.params import (EnumParam, PointerParam, StringParam)
+
 
 class ProtBioinformaticsDali(EMProtocol):
     """Query Dali server (http://ekhidna2.biocenter.helsinki.fi/dali) with a structure.
@@ -54,6 +57,7 @@ class ProtBioinformaticsDali(EMProtocol):
                          help="The web page will send an email to this address when the calculations are finished. "
                               "Copy the URL at the email in the Analyze Results of this protocol")
 
+
     # --------------------------- INSERT steps functions --------------------
     def _insertAllSteps(self):
         self._insertFunctionStep('searchStep',self.inputStructure.get().getFileName())
@@ -65,6 +69,48 @@ class ProtBioinformaticsDali(EMProtocol):
         args='-F "file1=@%s" -F "method=%s" -F "title=%s"  -F "address=%s" http://ekhidna.biocenter.helsinki.fi/cgi-bin/dali/dump.cgi' %\
              (outFileName,self.methodsDict[self.method.get()],self.title.get(),self.email.get())
         self.runJob("curl",args)
+
+
+    # --------------------------- OUTPUT function ------------------
+    @staticmethod
+    def constructOutput(fnTxt, prot):
+        fnDir, fnResults = os.path.split(fnTxt)
+        tokens = fnResults.split('-')
+        if len(tokens) > 1:
+            subset = tokens[1].split('.')[0]
+        else:
+            subset = ""
+
+        outputSet = SetOfDatabaseID.create(path=prot._getPath(), suffix=subset)
+        for line in open(fnTxt, "r"):
+            line = line.strip()
+            if line == "":
+                continue
+            elif line.startswith("# Structural equivalences"):
+                break
+            elif line.startswith("#"):
+                continue
+            else:
+                tokens = line.split()
+                pdbId = DatabaseID()
+                tokens2 = tokens[1].split('-')
+                pdbId.setDatabase("pdb")
+                pdbId.setDbId(tokens[1])
+                pdbId._pdbId = pwobj.String(tokens2[0])
+                if len(tokens2) > 1:
+                    pdbId._chain = pwobj.String(tokens2[1])
+                pdbId._PDBLink = pwobj.String("https://www.rcsb.org/structure/%s" % tokens2[0])
+                pdbId._DaliZscore = pwobj.Float(float(tokens[2]))
+                pdbId._DaliRMSD = pwobj.Float(float(tokens[3]))
+                pdbId._DaliSuperpositionLength = pwobj.Integer(int(tokens[4]))
+                pdbId._DaliSeqLength = pwobj.Integer(int(tokens[5]))
+                pdbId._DaliSeqIdentity = pwobj.Float(float(tokens[6]))
+                pdbId._DaliDescription = pwobj.String(" ".join(tokens[7:]))
+                outputSet.append(pdbId)
+        outputDict = {'outputDatabaseIds%s' % subset: outputSet}
+        prot._defineOutputs(**outputDict)
+        prot._defineSourceRelation(prot.inputStructure, outputSet)
+
 
     # --------------------------- UTILS functions ------------------
     def _validate(self):
@@ -84,3 +130,4 @@ class ProtBioinformaticsDali(EMProtocol):
 
     def _citations(self):
         return ['Holm2019']
+

--- a/bioinformatics/protocols/protocol_import_smallMolecules.py
+++ b/bioinformatics/protocols/protocol_import_smallMolecules.py
@@ -81,8 +81,13 @@ class ProtBioinformaticsImportSmallMolecules(EMProtocol):
         self._insertFunctionStep('importStep')
 
     def importStep(self):
+
         if not self.multiple.get():
-            copyFile(self.filePath.get(),self._getPath(os.path.split(self.filePath.get())[1]))
+
+            fnSmall = self._getExtraPath(os.path.split(self.filePath.get())[1]) #Puse Extra porque luego toma de ese folder
+            copyFile(self.filePath.get(), fnSmall)
+
+            #     copyFile(self.filePath.get(),self._getPath(os.path.split(self.filePath.get())[1]))
             fh = open(self.filePath.get())
             for line in fh.readlines():
                 tokens = line.split(',')
@@ -90,16 +95,19 @@ class ProtBioinformaticsImportSmallMolecules(EMProtocol):
                     fhSmile = open(self._getExtraPath(tokens[0].strip()+".smi"),'w')
                     fhSmile.write(tokens[1].strip()+"\n")
                     fhSmile.close()
-        else:
+
+        else: # Multiple:true, cuando hay más de un fichero que es necesario cargar en el objeto set
             for filename in glob.glob(os.path.join(self.filesPath.get(), self.filesPattern.get())):
                 fnSmall = self._getExtraPath(os.path.split(filename)[1])
                 copyFile(filename, fnSmall)
 
         outputSmallMolecules = SetOfSmallMolecules().create(path=self._getPath(),suffix='SmallMols')
-        for fnSmall in glob.glob(self._getExtraPath("*")):
+        # _getPath() Return a path inside the workingDir
+
+        for fnSmall in glob.glob(self._getExtraPath("*")): # _getExtraPath() Return a path inside the extra folder Dir
             smallMolecule = SmallMolecule(smallMolFilename=fnSmall)
 
-            if not fnSmall.endswith('.mae') and not fnSmall.endswith('.maegz'):
+            if not fnSmall.endswith('.mae') or not fnSmall.endswith('.maegz'):  #El problema de several format está aquí pero creo que era por conda. He cambiado and por or pero ahora han dejado de verse estructuras (noo sé si ha sido antes o despues)
                 fnRoot = os.path.splitext(os.path.split(fnSmall)[1])[0]
                 fnOut = self._getExtraPath("%s.png" % fnRoot)
                 args = Plugin.getPluginHome('utils/rdkitUtils.py') + " draw %s %s" % (fnSmall, fnOut)

--- a/bioinformatics/tests/__init__.py
+++ b/bioinformatics/tests/__init__.py
@@ -31,4 +31,5 @@ from .test_export_csv import TestExportcsv
 
 DataSet(name='ligandLibraries',
         folder='ligandLibraries',
-        files={})
+        files={}
+        )

--- a/bioinformatics/tests/__init__.py
+++ b/bioinformatics/tests/__init__.py
@@ -1,6 +1,6 @@
 # **************************************************************************
 # *
-# * Authors:    Yunior C. Fonseca Reyna (cfonseca@cnb.csic.es)
+# * Authors:    Alberto M. Parra Pérez (amparraperez@gmail.com)
 # *
 # * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *
@@ -24,3 +24,11 @@
 # *
 # **************************************************************************
 
+from pyworkflow.tests import *
+from .test_import_small_Molecules import TestImportSmallMolecules
+from .test_list_operate import TestListOperate
+from .test_export_csv import TestExportcsv
+
+DataSet(name='ligandLibraries',
+        folder='ligandLibraries',
+        files={})

--- a/bioinformatics/tests/test_export_csv.py
+++ b/bioinformatics/tests/test_export_csv.py
@@ -1,0 +1,93 @@
+# **************************************************************************
+# *
+# * Name:     TEST OF PROTOCOL_EXPORT_CSV.PY
+# *
+# * Authors:    Alberto M. Parra Pérez (amparraperez@gmail.com)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os, csv
+from pyworkflow.tests import *
+from bioinformatics.protocols import ProtBioinformaticsImportSmallMolecules as PISmallM
+from bioinformatics.protocols import ProtBioinformaticsExportCSV as PEcsv
+
+
+class TestImportBase(BaseTest):
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dsModBuild = DataSet.getDataSet("ligandLibraries")
+
+
+class TestImportData(TestImportBase):
+    """ Import a set of small molecules, a set of database IDs and a set of binding sites (last 2 coming soon)
+    """
+
+    def _importSetMolecules(self, path, pattern):
+        MULTIPLE_T = True
+        args = {'multiple': MULTIPLE_T,
+                'filesPath': path,
+                'filesPattern': pattern
+                }
+
+        prot1 = self.newProtocol(PISmallM, **args)
+        self.launchProtocol(prot1)
+        small_1 = prot1.outputSmallMols
+        return small_1
+
+class TestExportcsv(TestImportData):
+
+    def testCSVMolecules(self):
+
+        print("\nCSV Export Experiment:  4 small molecules different formats")
+
+        #Import Set of Small Molecules
+        path = self.dsModBuild.getFile(os.path.join("mix"))
+        pattern = "*"
+        smallM = self._importSetMolecules(path,pattern)
+
+        #Export CSV
+        args = {'inputSet': smallM}
+        pcsv = self.newProtocol(PEcsv, **args)
+        self.launchProtocol(pcsv)
+
+        #Search csv output in the directory tree of Runs
+        for root, directories, files in os.walk(os.path.join(os.getcwd(), "Runs")):
+            for name in files:
+                if name=="output.csv":
+                    pathcsv = os.path.join(root,name)
+
+        #Check if the file exits, if is not none and if it has got a correct number of entries
+        self.assertTrue(os.path.exists(pathcsv), "CSV file was not create. Check if its location changed")
+
+        csvtest = open(pathcsv)
+        self.assertIsNotNone(csvtest, "Created CSV is empty")
+
+        reader = csv.reader(csvtest)
+        lines = len(list(reader)) #Number of lines in the csv
+        self.assertTrue(lines==(4+1), "Created CSV is incomplete (missing entries (rows))")
+        #47 molecules and 1 header row
+
+        csvtest.close()
+

--- a/bioinformatics/tests/test_import_small_Molecules.py
+++ b/bioinformatics/tests/test_import_small_Molecules.py
@@ -1,0 +1,131 @@
+# **************************************************************************
+# *
+# * Name:     TEST OF PROTOCOL_IMPORT_SMALLMOLECULES.PY
+# *
+# * Authors:    Alberto M. Parra Pérez (amparraperez@gmail.com)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+from pyworkflow.tests import *
+from bioinformatics.protocols import ProtBioinformaticsImportSmallMolecules as PISmallM
+
+
+class TestImportBase(BaseTest):
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dsModBuild = DataSet.getDataSet("ligandLibraries")
+
+class TestImportSmallMolecules(TestImportBase):
+    MULTIPLE_T = True
+    MULTIPLE_F = False
+    filesPattern = '*'
+
+    def testImport_one_mol_smi(self):
+        """ Import a single file of a small molecule provided by the user in smi format
+        """
+        print("\nImport Experiment:  1 molecule smi format")
+
+        args = {'multiple': self.MULTIPLE_F,
+                'filePath': self.dsModBuild.getFile(os.path.join("mix", "2000.smi"))
+                }
+
+        prot1 = self.newProtocol(PISmallM, **args)
+        self.launchProtocol(prot1)
+        small_1 = prot1.outputSmallMols
+        self.assertIsNotNone(small_1,
+                             "There was a problem with the import")
+        self.assertTrue(small_1.getSize()==1,
+                        "There was a problem with the import and the SetOfSmallMolecules is empty")
+
+    def testImport_one_mol_pdb(self):
+        """ Import a single file of a small molecule provided by the user in pdb format
+        """
+        print("\nImport Experiment:  1 molecule pdb format")
+
+        args = {'multiple': self.MULTIPLE_F,
+                'filePath': self.dsModBuild.getFile(os.path.join("mix", "2000_noH.pdb"))
+                }
+
+        prot1 = self.newProtocol(PISmallM, **args)
+        self.launchProtocol(prot1)
+        small_1 = prot1.outputSmallMols
+        self.assertIsNotNone(small_1,
+                             "There was a problem with the import")
+        self.assertTrue(small_1.getSize()==1,
+                        "There was a problem with the import and the SetOfSmallMolecules is empty")
+
+    def testImport_one_mol_mae(self):
+        """ Import a single file of a small molecule provided by the user in mae format
+        """
+        print("\nImport Experiment:  1 molecule mae format")
+
+        args = {'multiple': self.MULTIPLE_F,
+                'filePath': self.dsModBuild.getFile(os.path.join("mix", "2000.mae"))
+                }
+
+        prot1 = self.newProtocol(PISmallM, **args)
+        self.launchProtocol(prot1)
+        small_1 = prot1.outputSmallMols
+        self.assertIsNotNone(small_1,
+                             "There was a problem with the import")
+        self.assertTrue(small_1.getSize()==1,
+                        "There was a problem with the import and the SetOfSmallMolecules is empty")
+
+    def testImport_one_mol_sdf(self):
+        """ Import a single file of a small molecule provided by the user in sdf format
+        """
+        print("\nImport Experiment:  1 molecule sdf format")
+
+        args = {'multiple': self.MULTIPLE_F,
+                'filePath': self.dsModBuild.getFile(os.path.join("mix", "2000.sdf"))
+                }
+
+        prot1 = self.newProtocol(PISmallM, **args)
+        self.launchProtocol(prot1)
+        small_1 = prot1.outputSmallMols
+        self.assertIsNotNone(small_1,
+                             "There was a problem with the import")
+        self.assertTrue(small_1.getSize()==1,
+                        "There was a problem with the import and the SetOfSmallMolecules is empty")
+
+
+    def testImport_mols_mix(self):
+        """Import several files of a small molecule provided by the user in different formats
+        """
+        print("\nImport Experiment:  4 molecules in several formats")
+
+        args = {'multiple': self.MULTIPLE_T,
+                'filesPath': self.dsModBuild.getFile(os.path.join("mix")),
+                'filesPattern': self.filesPattern
+                }
+
+        prot1 = self.newProtocol(PISmallM, **args)
+        self.launchProtocol(prot1)
+        small_1 = prot1.outputSmallMols
+        self.assertIsNotNone(small_1,
+                             "There was a problem with the import")
+        self.assertTrue(small_1.getSize()==4,
+                        "There was a problem with the import and the SetOfSmallMolecules is empty")
+

--- a/bioinformatics/tests/test_list_operate.py
+++ b/bioinformatics/tests/test_list_operate.py
@@ -1,0 +1,332 @@
+# **************************************************************************
+# *
+# * Name:     TEST OF PROTOCOL_LIST_OPERATE.PY
+# *
+# * Authors:    Alberto M. Parra Pérez (amparraperez@gmail.com)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+from pathlib import Path
+from pyworkflow.tests import *
+from pyworkflow.protocol import *
+from pwem.protocols.protocol_import import ProtImportPdb
+from bioinformatics.protocols import ProtBioinformaticsListOperate as LOperate
+from bioinformatics.protocols import ProtBioinformaticsDali as DALI
+
+
+class TestImportBase(BaseTest):
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dsModBuild = DataSet.getDataSet("ligandLibraries")
+
+
+class TestCreateOutput(TestImportBase):
+    """ Create a realistic output of Dali using an old job (pdb id used:6zow)
+    """
+
+    def _importPDB(self, path):
+        inputPdbData = 1 #file
+        args = {'inputPdbData': inputPdbData,
+                'pdbFile': path
+                }
+
+        prot1 = self.newProtocol(ProtImportPdb, **args)
+        self.launchProtocol(prot1)
+        global pdb
+        pdb = prot1.outputPdb
+        return pdb
+
+    def getDalioutputs(self, protocol):
+        fnBaseDir = self.dsModBuild.getFile(os.path.join("dali_output"))
+        for fn in Path(fnBaseDir).rglob('*.txt'):
+            protocol.constructOutput(str(fn), protocol)
+
+
+
+class TestListOperate(TestCreateOutput):
+
+    def test_1filter(self):
+        """1. Filter a column using different ways
+        """
+
+        print("\n Filtering a SetOfDatabaseID object by a column")
+
+        # Import a pdb file
+        path = self.dsModBuild.getFile(os.path.join("proteinpdb", "5xjh.pdb"))
+        pdb = self._importPDB(path)
+
+        #Dali
+        args = {'inputStructure': pdb,
+                'method': 0, #search
+                'title': 'test_dali_5xjh',
+                'email': 'amparraperez@gmail.com'}
+
+        prot1 = self.newProtocol(DALI, **args)
+        prot1._store()
+        self.getDalioutputs(prot1)
+        prot1.setStatus(STATUS_FINISHED)
+
+        global outputDali; global outputDali2
+        outputDali = prot1.outputDatabaseIds90
+        outputDali2 = prot1.outputDatabaseIds50
+
+        self.assertIsNotNone(outputDali, "Error in creation of SetOfDatabaseID by DALI - It is NONE")
+        self.assertTrue(outputDali.getSize() == 432, "The size of the SetOfDatabaseID is wrong. It should be 432 ")
+        n_columns = len(list(outputDali.getFirstItem().getAttributes()))
+        self.assertTrue(n_columns == 11)  # 2 fixed columns + 9 given
+
+
+        # SET filtering :  _DaliZscore column ( >= 40)
+        args = {'operation': 0,  # Filter
+                'inputSet':outputDali,
+                'filterColumn': '_DaliZscore',
+                'filterOp': 2,  # >=
+                'filterValue': 40}
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new filtered SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 7, "Error in filtering >= 40 of _DaliZscore column")
+
+
+        # SET filtering :  _DaliZscore column ( 25 >= value <= 52 )
+        args = {'operation': 0,  # Filter
+                'inputSet': outputDali,
+                'filterColumn': '_DaliZscore',
+                'filterOp': 6,  # between
+                'filterValue': 52,
+                'filterValue2': 25}
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new filtered SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize()==8, "Error in filtering 25 >= value <= 52 of _DaliZscore column")
+
+        # SET filtering :  _DaliZscore column ( >= 40)
+        args = {'operation': 0,  # Filter
+                'inputSet': outputDali,
+                'filterColumn': '_pdbId',
+                'filterOp': 7,  # startwith
+                'filterValue': "6"}
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new filtered SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 57, "Error in filtering >_pdbId column. Startwith does not work")
+
+        # SET filtering :  _DaliZscore column ( >= 40)
+        args = {'operation': 0,  # Filter
+                'inputSet': outputDali,
+                'filterColumn': '_DaliDescription',
+                'filterOp': 9,  # contains
+                'filterValue': "ESTERASE"}
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new filtered SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 104, "Error in filtering _DaliDescription column searching the ESTERASE word")
+
+
+    def test_2keepcolumns(self):
+        """2. Keep only 2 columns and all entries
+        """
+        print("\n Keeping 2 interesting columns in a new SetOfDatabaseID")
+
+        # Keep_column :  _pdbId column
+        args = {'operation': 1,
+                'inputSet': outputDali,
+                'keepColumns': '_pdbId ; _DaliZscore'
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 432, "Error in creation of a new SetOfDatabaseID. It is different from the original regarding the number of entries")
+        n_columns = len(list(setf.getFirstItem().getAttributes()))
+        self.assertTrue(n_columns == 2+2) #2 fixed columns + 2 given
+
+
+    def test_3unique(self):
+        """3. Keep unique entries in 1 column
+        """
+        print("\n Keeping unique entries in 1 column in a new SetOfDatabaseID. No biological sense")
+
+
+        args = {'operation': 2,  # Unique
+                'inputSet': outputDali,
+                'filterColumn': '_DaliDescription'
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 302, "Error in creation of a new SetOfDatabaseID. There is not unique entries")
+
+
+    def test_4top(self):
+        """4. Keep 10 top and 10 top 5% entries regarding 1 column
+        """
+        print("\n Keeping a number (10 or 5%) of entries regarding if it is in the top  regarding 1 column")
+
+        # Keep 10 top entries :
+        args = {'operation': 3,
+                'inputSet': outputDali,
+                'filterColumn': '_DaliZscore',
+                'N': 10
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 10, "Error in creation of a new SetOfDatabaseID. The number of entries is not the indicated one")
+
+        for entry in setf:
+            first_value = entry.getAttributeValue('_DaliZscore')
+            break
+
+        self.assertTrue(first_value == 51.4, "Failed to extract all top 10 entries regarding _DaliZscorecolumn")
+
+        # Keep 5 % top entries :
+        args = {'operation': 5,
+                'inputSet': outputDali,
+                'filterColumn': '_DaliZscore',
+                'N': 10
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 23, "Error in creation of a new SetOfDatabaseID. There is not unique entries")
+
+        for entry in setf:
+            first_value = entry.getAttributeValue('_DaliZscore')
+            break
+
+        self.assertTrue(first_value == 51.4, "Failed to extract all 5% top 10 entries regarding _DaliZscorecolumn")
+
+
+    def test_5count(self):
+        """5. Count the number of same entries
+        """
+        print("\n Count the number of same entries regarding 1 column")
+
+
+        args = {'operation': 7,
+                'inputSet': outputDali,
+                'filterColumn': '_DaliZscore'
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 432, "Error in creation of a new SetOfDatabaseID.")
+        n_columns = len(list(setf.getFirstItem().getAttributes()))
+        self.assertTrue(n_columns == 2+9+1, "Column count was not created") #2 fixed columns + 9 given + 1 count
+
+
+    def test_6intersect(self):
+        """6. Intersect 2 SetOfDatabaseID using the column called _pdbId
+        """
+        print("\n Intersect 2 SetOfDatabaseID using 1 column")
+
+        args = {'operation': 8,
+                'inputSet': outputDali,
+                'secondSet': outputDali2,
+                'filterColumn': '_pdbId' # Without chain information. With that info there is only 1 difference (311 in intersection 312 in 50%)
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 314, "Error in creation of a new SetOfDatabaseID. The intersection was wrong")
+
+
+    def test_7sort(self):
+        """6. Sort (Ascending or Descending way) a SetOfDatabaseID regarding 1 column (_DaliZscore)
+        """
+        print("\n Sort a SetOfDatabaseID regarding 1 column (Ascending or Descending way)")
+
+        args = {'operation': 9,
+                'inputSet': outputDali,
+                'filterColumn': '_DaliZscore',# Without chain information. With that info there is only 1 difference (311 in intersection 312 in 50%)
+                'direction': 0 #ascending
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 432, "Error in creation of a new SetOfDatabaseID")
+
+        for entry in setf:
+            first_value = entry.getAttributeValue('_DaliZscore')
+            break
+
+        self.assertTrue(first_value == 2.1, "Failed to sort (ascending) the SetDatabaseID regarding _DaliZscorecolumn")
+
+
+        args = {'operation': 9,
+                'inputSet': outputDali,
+                'filterColumn': '_DaliZscore',# Without chain information. With that info there is only 1 difference (311 in intersection 312 in 50%)
+                'direction': 1 #descending
+                }
+
+        setf = self.newProtocol(LOperate, **args)
+        self.launchProtocol(setf)
+        setf = setf.output
+
+        self.assertIsNotNone(setf, "Error in creation of a new SetOfDatabaseID - It is NONE")
+        self.assertTrue(setf.getSize() == 432, "Error in creation of a new SetOfDatabaseID")
+
+        for entry in setf:
+            first_value = entry.getAttributeValue('_DaliZscore')
+            break
+
+        self.assertTrue(first_value == 51.4, "Failed to sort (descending) the SetDatabaseID regarding _DaliZscorecolumn")
+

--- a/bioinformatics/viewers/viewer_protocol_dali.py
+++ b/bioinformatics/viewers/viewer_protocol_dali.py
@@ -80,43 +80,6 @@ class ProtBioinformaticsDaliViewer(ProtocolViewer):
 
             if not hasattr(self.protocol,"outputIds"):
                 for fn in Path(fnBaseDir).rglob('*.txt'):
-                    self.constructOutput(str(fn))
+                    self.protocol.constructOutput(str(fn), self.protocol)
         return views
 
-    def constructOutput(self,fnTxt):
-        fnDir, fnResults=os.path.split(fnTxt)
-        tokens=fnResults.split('-')
-        if len(tokens)>1:
-            subset=tokens[1].split('.')[0]
-        else:
-            subset=""
-
-        outputSet=SetOfDatabaseID.create(path=self._getPath(),suffix=subset)
-        for line in open(fnTxt,"r"):
-            line=line.strip()
-            if line=="":
-                continue
-            elif line.startswith("# Structural equivalences"):
-                break
-            elif line.startswith("#"):
-                continue
-            else:
-                tokens=line.split()
-                pdbId=DatabaseID()
-                tokens2=tokens[1].split('-')
-                pdbId.setDatabase("pdb")
-                pdbId.setDbId(tokens[1])
-                pdbId._pdbId=pwobj.String(tokens2[0])
-                if len(tokens2)>1:
-                    pdbId._chain=pwobj.String(tokens2[1])
-                pdbId._PDBLink=pwobj.String("https://www.rcsb.org/structure/%s"%tokens2[0])
-                pdbId._DaliZscore=pwobj.Float(float(tokens[2]))
-                pdbId._DaliRMSD=pwobj.Float(float(tokens[3]))
-                pdbId._DaliSuperpositionLength=pwobj.Integer(int(tokens[4]))
-                pdbId._DaliSeqLength=pwobj.Integer(int(tokens[5]))
-                pdbId._DaliSeqIdentity=pwobj.Float(float(tokens[6]))
-                pdbId._DaliDescription=pwobj.String(" ".join(tokens[7:]))
-                outputSet.append(pdbId)
-        outputDict = {'outputDatabaseIds%s' % subset: outputSet}
-        self.protocol._defineOutputs(**outputDict)
-        self.protocol._defineSourceRelation(self.protocol.inputStructure, outputSet)


### PR DESCRIPTION
Some changes have been made in the protocols such as: 1) adding the between option in the filter operation of the list_operate protocol, 2) changing the constructor of the Dali output from the viewer to protocol (protocol_dali) as a static method, and 3) changing to the Extra folder where the ligand files are copied when only one molecule is imported using the import_Small_Molecules protocol. Also, some tests of the protocols have been added. These still would not work because there is no test data in Scipion's Datatest files.